### PR TITLE
Add support for postgres 13

### DIFF
--- a/pgextras/sql_constants.py
+++ b/pgextras/sql_constants.py
@@ -53,8 +53,8 @@ VACUUM_STATS = """
 
 OUTLIERS = """
     SELECT {query} AS qry,
-        interval '1 millisecond' * total_time AS exec_time,
-        to_char((total_time/sum(total_time) OVER()) * 100,
+        interval '1 millisecond' * {tot_time} AS exec_time,
+        to_char(({tot_time}/sum({tot_time}) OVER()) * 100,
             'FM90D0') || '%' AS
         prop_exec_time,
         to_char(calls, 'FM999G999G999G990') AS ncalls,
@@ -67,7 +67,7 @@ OUTLIERS = """
         WHERE usename = current_user
         LIMIT 1
     )
-    ORDER BY total_time DESC
+    ORDER BY {tot_time} DESC
     LIMIT 10
 """
 
@@ -101,8 +101,8 @@ INDEX_USAGE = """
 """
 
 CALLS = """
-    {select} interval '1 millisecond' * total_time AS exec_time,
-        to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'
+    {select} interval '1 millisecond' * {tot_time} AS exec_time,
+        to_char(({tot_time}/sum({tot_time}) OVER()) * 100, 'FM90D0') || '%'
             AS prop_exec_time,
         to_char(calls, 'FM999G999G990') AS ncalls,
         interval '1 millisecond' * (blk_read_time + blk_write_time)


### PR DESCRIPTION
1. Using `packaging.version.parse` to parse the version numbers. Because of the existing string comparison, `_is_pg_at_least_nine_two` will be False for postgres versions 10 and above as `"14" < "9.2"`. `packaging.version.parse` resolves this.
2. `total_time` has been renamed to `total_exec_time` in postgres 13 and in this PR, I have added support for it.